### PR TITLE
US-016: Organization Home Dashboard

### DIFF
--- a/opportunity_app/urls.py
+++ b/opportunity_app/urls.py
@@ -1,6 +1,10 @@
+import os
+
+from django.conf import settings
 from django.contrib import admin
-from django.urls import path, include
 from django.contrib.auth.views import LogoutView
+from django.urls import include, path, re_path
+from django.views.static import serve
 
 
 urlpatterns = [
@@ -9,3 +13,16 @@ urlpatterns = [
     path('accounts/', include('accounts.urls')),
     path('logout/', LogoutView.as_view(next_page='welcome'), name='logout'),
 ]
+
+# When DEBUG is False, runserver does not serve STATICFILES_DIRS. Teammates with
+# DJANGO_DEBUG=false then see completely unstyled pages. Serve /static/ from the
+# repo `static/` folder unless disabled (e.g. production behind nginx + collectstatic).
+_serve_static = os.getenv('DJANGO_SERVE_STATIC', 'true').lower() in ('1', 'true', 'yes')
+if _serve_static and getattr(settings, 'STATICFILES_DIRS', None):
+    urlpatterns += [
+        re_path(
+            r'^static/(?P<path>.*)$',
+            serve,
+            {'document_root': str(settings.STATICFILES_DIRS[0])},
+        ),
+    ]

--- a/opportunity_app/urls.py
+++ b/opportunity_app/urls.py
@@ -6,23 +6,24 @@ from django.contrib.auth.views import LogoutView
 from django.urls import include, path, re_path
 from django.views.static import serve
 
-
-urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include('pages.urls')),
-    path('accounts/', include('accounts.urls')),
-    path('logout/', LogoutView.as_view(next_page='welcome'), name='logout'),
-]
-
-# When DEBUG is False, runserver does not serve STATICFILES_DIRS. Teammates with
-# DJANGO_DEBUG=false then see completely unstyled pages. Serve /static/ from the
-# repo `static/` folder unless disabled (e.g. production behind nginx + collectstatic).
+# When DEBUG is False, runserver does not serve STATICFILES_DIRS. Also, `path('', include(...))`
+# matches *every* URL including `/static/...`, so static routes MUST come before that catch-all
+# or they are never reached (pages.urls has no static/* patterns → 404).
 _serve_static = os.getenv('DJANGO_SERVE_STATIC', 'true').lower() in ('1', 'true', 'yes')
+_static_urlpatterns = []
 if _serve_static and getattr(settings, 'STATICFILES_DIRS', None):
-    urlpatterns += [
+    _static_urlpatterns = [
         re_path(
             r'^static/(?P<path>.*)$',
             serve,
             {'document_root': str(settings.STATICFILES_DIRS[0])},
         ),
     ]
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    *_static_urlpatterns,
+    path('', include('pages.urls')),
+    path('accounts/', include('accounts.urls')),
+    path('logout/', LogoutView.as_view(next_page='welcome'), name='logout'),
+]

--- a/pages/views.py
+++ b/pages/views.py
@@ -249,11 +249,10 @@ def faq(request):
 
 @login_required
 def dashboard(request):
+    if hasattr(request.user, 'user_type') and request.user.user_type == 'organization':
+        return redirect('organization_dashboard')
     role = request.user.user_type.title() if hasattr(request.user, 'user_type') else 'User'
     context = {'role': role}
-    if hasattr(request.user, 'user_type') and request.user.user_type == 'organization':
-        unread_count = Message.objects.filter(recipient=request.user, is_read=False).count()
-        context['unread_message_count'] = unread_count
     return render(request, 'pages/dashboard.html', context)
 
 
@@ -295,16 +294,33 @@ def mark_opportunity_pending(request, student_opportunity_id):
 def organization_dashboard(request):
     if request.user.user_type != 'organization':
         return redirect('screen1')
-    recent_applications = Application.objects.filter(opportunity__organization=request.user).select_related('student', 'opportunity').order_by('-applied_date')[:10]
-    pending_count = Application.objects.filter(opportunity__organization=request.user, status='pending').count()
-    accepted_count = Application.objects.filter(opportunity__organization=request.user, status='accepted').count()
-    opportunities_count = Opportunity.objects.filter(organization=request.user, is_active=True).count()
+
+    org = request.user
+    recent_applications = (
+        Application.objects.filter(opportunity__organization=org)
+        .select_related('student', 'opportunity')
+        .order_by('-applied_date')[:5]
+    )
+    pending_count = Application.objects.filter(opportunity__organization=org, status='pending').count()
+    accepted_count = Application.objects.filter(opportunity__organization=org, status='accepted').count()
+    opportunities_count = Opportunity.objects.filter(organization=org, is_active=True).count()
+    unread_message_count = Message.objects.filter(recipient=org, is_read=False).count()
+
+    full = f"{org.first_name} {org.last_name}".strip()
+    org_name = full if full else org.email.split('@')[0].replace('_', ' ').title()
+    initials_source = full or org_name
+    initials = ''.join(part[:1] for part in initials_source.split() if part)[:2].upper() or org_name[:1].upper()
+
     context = {
+        'org': org,
+        'org_name': org_name,
+        'initials': initials,
         'recent_applications': recent_applications,
         'pending_count': pending_count,
         'accepted_count': accepted_count,
         'total_volunteers': accepted_count,
         'opportunities_count': opportunities_count,
+        'unread_message_count': unread_message_count,
     }
     return render(request, 'pages/organization_dashboard.html', context)
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -174,3 +174,66 @@ fieldset.form-field { border:1px solid #e5e7eb; border-radius:.6rem; padding:.75
 .auth-links a:hover { text-decoration: underline; }
 .auth-note { margin-top: 1rem; color: var(--auth-muted); font-size: 0.82rem; border-top: 1px dashed #d6deee; padding-top: 0.8rem; }
 @media (max-width: 600px) { .auth-card { padding: 1.25rem; border-radius: 12px; } .auth-links { flex-direction: column; align-items: flex-start; } }
+
+/* Organization Home Dashboard (US-016) – shared layout helpers */
+.student-home { display: flex; flex-direction: column; gap: 1.75rem; padding: 1rem 0 3rem; }
+
+.home-greeting { display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; color: #fff; border-radius: 1rem; padding: 1.75rem 2rem; flex-wrap: wrap; }
+.home-greeting__text { flex: 1; min-width: 220px; }
+.home-greeting__eyebrow { margin: 0 0 .35rem; font-size: .75rem; font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: rgba(255,255,255,.75); }
+.home-greeting__title { margin: 0 0 .35rem; font-size: 1.85rem; font-weight: 700; line-height: 1.15; }
+.home-greeting__subtitle { margin: 0; font-size: .95rem; color: rgba(255,255,255,.85); }
+.home-greeting__avatar { width: 64px; height: 64px; border-radius: 50%; background: rgba(255,255,255,.18); border: 2px solid rgba(255,255,255,.4); display: flex; align-items: center; justify-content: center; font-size: 1.4rem; font-weight: 700; text-transform: uppercase; flex-shrink: 0; }
+
+.home-actions-grid { display: grid; gap: 1rem; }
+.home-actions-grid--three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.home-actions-grid--two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+@media (max-width: 720px) { .home-actions-grid--three, .home-actions-grid--two { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 480px) { .home-actions-grid--three, .home-actions-grid--two { grid-template-columns: 1fr; } }
+
+.action-card { display: flex; flex-direction: column; align-items: flex-start; gap: .35rem; padding: 1.1rem 1.15rem; background: #fff; border: 1px solid #e5e7eb; border-radius: .9rem; text-decoration: none; color: #0f172a; transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease; min-height: 120px; }
+.action-card:hover { transform: translateY(-2px); box-shadow: 0 10px 24px rgba(15,23,42,.08); border-color: #99f6e4; }
+.action-card__icon { font-size: 1.5rem; line-height: 1; }
+.action-card__title { font-size: 1.02rem; font-weight: 600; }
+.action-card__meta { font-size: .85rem; color: #64748b; }
+
+.org-home .home-greeting { background: linear-gradient(135deg, #0f766e 0%, #0d9488 60%, #14b8a6 100%); box-shadow: 0 12px 30px rgba(13,148,136,.18); }
+.org-home .action-card--accent { background: linear-gradient(135deg, #ecfeff 0%, #ffffff 100%); border-color: #99f6e4; }
+.org-home .action-card--accent .action-card__title { color: #0f766e; }
+
+.home-recommended { background: #fff; border: 1px solid #e5e7eb; border-radius: 1rem; padding: 1.5rem 1.5rem 1rem; }
+.home-recommended__header { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.home-recommended__title { margin: 0; font-size: 1.25rem; font-weight: 700; color: #0f172a; }
+.home-recommended__link { text-decoration: none; color: #0f766e; font-size: .9rem; font-weight: 600; }
+.home-recommended__link:hover { text-decoration: underline; }
+
+.recent-apps__list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; }
+.recent-app-row { display: flex; align-items: center; gap: 1rem; padding: .85rem 0; border-top: 1px solid #f1f5f9; flex-wrap: wrap; }
+.recent-app-row:first-child { border-top: none; }
+.recent-app-row.status-accepted { background: linear-gradient(90deg,rgba(34,197,94,.06),transparent); border-radius: .5rem; padding-left: .5rem; }
+.recent-app-row.status-declined { opacity: .72; }
+.recent-app-row__person { display: flex; align-items: center; gap: .75rem; flex: 1; min-width: 180px; }
+.recent-app-row__avatar { width: 38px; height: 38px; border-radius: 50%; background: linear-gradient(135deg,#6366f1,#8b5cf6); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: .95rem; text-transform: uppercase; flex-shrink: 0; }
+.recent-app-row__info { min-width: 0; }
+.recent-app-row__name { margin: 0 0 .1rem; font-size: .95rem; font-weight: 600; color: #0f172a; }
+.recent-app-row__opp { margin: 0; font-size: .82rem; color: #64748b; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.recent-app-row__meta { font-size: .82rem; color: #94a3b8; white-space: nowrap; flex-shrink: 0; }
+.recent-app-row__actions { display: flex; gap: .45rem; align-items: center; flex-shrink: 0; margin-left: auto; }
+.recommended-empty { margin: .5rem 0 1rem; color: #64748b; font-size: .95rem; }
+
+.btn-sm { padding: .38rem .8rem; border-radius: .5rem; font-size: .82rem; font-weight: 600; border: 1px solid transparent; cursor: pointer; text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center; transition: background-color .15s ease, transform .15s ease, box-shadow .15s ease; }
+.btn-sm--ghost { background: #f1f5f9; color: #334155; border-color: #e2e8f0; }
+.btn-sm--ghost:hover { background: #e2e8f0; }
+.btn-sm--accept { background: #16a34a; color: #fff; }
+.btn-sm--accept:hover { background: #15803d; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(22,163,74,.25); }
+.btn-sm--decline { background: #fff; color: #dc2626; border-color: #fecaca; }
+.btn-sm--decline:hover { background: #fef2f2; border-color: #ef4444; }
+
+.status-pill { padding: .25rem .7rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
+.status-pill.pill-accepted { background: #dcfce7; color: #166534; }
+.status-pill.pill-declined { background: #fee2e2; color: #991b1b; }
+.status-pill.pill-pending { background: #fef3c7; color: #92400e; }
+
+@media (max-width: 680px) { .recent-app-row { flex-wrap: wrap; } .recent-app-row__actions { margin-left: 0; width: 100%; } }
+@media (max-width: 640px) { .home-greeting { padding: 1.4rem; } .home-greeting__title { font-size: 1.5rem; } }
+

--- a/templates/pages/organization_dashboard.html
+++ b/templates/pages/organization_dashboard.html
@@ -1,590 +1,150 @@
 {% extends 'base.html' %}
-{% load static %}
 
-{% block title %}Organization Dashboard - Opportunity App{% endblock %}
+{% block title %}Organization Home - Opportunity App{% endblock %}
 
 {% block content %}
-<div class="org-dashboard">
-    <!-- Header Section -->
-    <div class="dashboard-header">
-        <div class="header-greeting">
-            <h1>Hello, {{ request.user.display_name }} 👋</h1>
-            <p class="subtitle">Here's your organization overview</p>
-        </div>
+<section class="student-home org-home">
+  <header class="home-greeting">
+    <div class="home-greeting__text">
+      <p class="home-greeting__eyebrow">Organization Home</p>
+      <h1 class="home-greeting__title">Hello, {{ org_name }}</h1>
+      <p class="home-greeting__subtitle">Review new applications and manage your volunteer pipeline.</p>
+    </div>
+    <div class="home-greeting__avatar" aria-hidden="true">{{ initials|default:"O" }}</div>
+  </header>
+
+  <div class="home-actions-grid home-actions-grid--three">
+    <a class="action-card" href="{% url 'organization_applications' %}">
+      <span class="action-card__icon" aria-hidden="true">📋</span>
+      <span class="action-card__title">Review Volunteers ({{ pending_count }})</span>
+      <span class="action-card__meta">Pending applications</span>
+    </a>
+
+    <a class="action-card" href="{% url 'organization_profile' org.id %}">
+      <span class="action-card__icon" aria-hidden="true">👤</span>
+      <span class="action-card__title">Your Profile</span>
+      <span class="action-card__meta">View &amp; edit details</span>
+    </a>
+
+    <a class="action-card" href="{% url 'organization_applications' %}">
+      <span class="action-card__icon" aria-hidden="true">👥</span>
+      <span class="action-card__title">Current Volunteers ({{ total_volunteers }})</span>
+      <span class="action-card__meta">Accepted applicants</span>
+    </a>
+  </div>
+
+  <div class="home-actions-grid home-actions-grid--two">
+    <a class="action-card action-card--accent" href="{% url 'organization_post_opportunity' %}">
+      <span class="action-card__icon" aria-hidden="true">📝</span>
+      <span class="action-card__title">Post Opportunity</span>
+      <span class="action-card__meta">Publish a new role</span>
+    </a>
+
+    <a class="action-card" href="{% url 'organization_inbox' %}">
+      <span class="action-card__icon" aria-hidden="true">💬</span>
+      <span class="action-card__title">Share News Update</span>
+      <span class="action-card__meta">
+        {% if unread_message_count %}{{ unread_message_count }} unread{% else %}Send a message{% endif %}
+      </span>
+    </a>
+  </div>
+
+  <section class="home-recommended recent-apps">
+    <div class="home-recommended__header">
+      <h2 class="home-recommended__title">Recent Applications</h2>
+      <a class="home-recommended__link" href="{% url 'organization_applications' %}">See all &rsaquo;</a>
     </div>
 
-    <!-- Stats Cards -->
-    <div class="stats-grid">
-        <div class="stat-card stat-pending">
-            <div class="stat-icon-wrap">
-                <span class="stat-icon">📋</span>
+    {% if recent_applications %}
+      <ul class="recent-apps__list">
+        {% for app in recent_applications %}
+          <li class="recent-app-row status-{{ app.status }}" id="application-{{ app.id }}">
+            <div class="recent-app-row__person">
+              <span class="recent-app-row__avatar" aria-hidden="true">{{ app.student.display_name|first|upper }}</span>
+              <div class="recent-app-row__info">
+                <p class="recent-app-row__name">{{ app.student.display_name }}</p>
+                <p class="recent-app-row__opp">{{ app.opportunity.title }}</p>
+              </div>
             </div>
-            <div class="stat-content">
-                <p class="stat-label">Review Volunteers</p>
-                <p class="stat-number">{{ pending_count }}</p>
-            </div>
-        </div>
 
-        <a href="{% url 'organization_profile' %}" class="stat-card stat-profile" style="text-decoration:none;color:inherit;">
-            <div class="stat-icon-wrap">
-                <span class="stat-icon">👤</span>
-            </div>
-            <div class="stat-content">
-                <p class="stat-label">Your Profile</p>
-                <p class="stat-number stat-link-text">View →</p>
-            </div>
-        </a>
+            <span class="recent-app-row__meta">Applied {{ app.applied_date|timesince }} ago</span>
 
-        <div class="stat-card stat-volunteers">
-            <div class="stat-icon-wrap">
-                <span class="stat-icon">👥</span>
+            <div class="recent-app-row__actions" data-app-id="{{ app.id }}">
+              {% if app.status == 'pending' %}
+                <a class="btn-sm btn-sm--ghost" href="{% url 'applicant_profile' app.student.id %}">View Profile</a>
+                <button class="btn-sm btn-sm--accept" data-action="accept" data-app-id="{{ app.id }}">Accept</button>
+                <button class="btn-sm btn-sm--decline" data-action="decline" data-app-id="{{ app.id }}">Decline</button>
+              {% else %}
+                <a class="btn-sm btn-sm--ghost" href="{% url 'applicant_profile' app.student.id %}">View Profile</a>
+                <span class="status-pill pill-{{ app.status }}">{{ app.get_status_display }}</span>
+              {% endif %}
             </div>
-            <div class="stat-content">
-                <p class="stat-label">Current Volunteers</p>
-                <p class="stat-number">{{ total_volunteers }}</p>
-            </div>
-        </div>
-    </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="recommended-empty">No applications yet — they'll appear here as students apply.</p>
+    {% endif %}
+  </section>
+</section>
 
-    <!-- Quick Actions -->
-    <div class="quick-actions">
-        <a href="{% url 'organization_post_opportunity' %}" class="action-btn action-primary" id="post-opportunity-btn">
-            <span class="action-icon">📝</span> Post New Opportunity
-        </a>
-        <a href="{% url 'organization_messages' %}" class="action-btn action-secondary" id="messages-btn">
-            <span class="action-icon">💬</span> Share News Update
-        </a>
-    </div>
-
-    <!-- Recent Applications Section -->
-    <div class="recent-applications-section">
-        <div class="section-header">
-            <h2>Recent Applications</h2>
-            {% if recent_applications %}
-            <span class="apps-badge">{{ recent_applications|length }}</span>
-            {% endif %}
-        </div>
-
-        {% if recent_applications %}
-        <div class="applications-list">
-            {% for app in recent_applications %}
-            <div class="application-card status-{{ app.status }}" id="application-{{ app.id }}">
-                <div class="app-left">
-                    <div class="applicant-avatar">
-                        {{ app.student.display_name|first }}
-                    </div>
-                    <div class="applicant-info">
-                        <h3 class="applicant-name">{{ app.student.display_name }}</h3>
-                        <p class="opportunity-title">{{ app.opportunity.title }}</p>
-                        <p class="applied-time">Applied {{ app.applied_date|timesince }} ago</p>
-                    </div>
-                </div>
-                <div class="app-right">
-                    {% if app.status == 'pending' %}
-                    <div class="app-actions">
-                        <a href="{% url 'applicant_profile' app.student.id %}" class="action-btn-sm action-view" id="view-{{ app.id }}">
-                            View Profile
-                        </a>
-                        <button class="action-btn-sm action-accept accept-btn" data-app-id="{{ app.id }}" id="accept-{{ app.id }}">
-                            Accept
-                        </button>
-                        <button class="action-btn-sm action-decline decline-btn" data-app-id="{{ app.id }}" id="decline-{{ app.id }}">
-                            Decline
-                        </button>
-                    </div>
-                    {% else %}
-                    <div class="app-status-display">
-                        <span class="status-pill pill-{{ app.status }}">{{ app.get_status_display }}</span>
-                        <a href="{% url 'applicant_profile' app.student.id %}" class="action-btn-sm action-view" id="view-{{ app.id }}">
-                            View
-                        </a>
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-        {% else %}
-        <div class="empty-state">
-            <div class="empty-icon">📭</div>
-            <p class="empty-title">No applications yet</p>
-            <p class="empty-subtitle">Once students apply to your opportunities, they'll appear here.</p>
-        </div>
-        {% endif %}
-    </div>
-</div>
-
-<!-- JavaScript for Accept/Decline Actions -->
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('.accept-btn').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const appId = this.dataset.appId;
-            handleApplication(appId, 'accept');
-        });
-    });
+  (function () {
+    function getCookie(name) {
+      const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]+)'));
+      return match ? decodeURIComponent(match[1]) : '';
+    }
 
-    document.querySelectorAll('.decline-btn').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const appId = this.dataset.appId;
-            if (confirm('Are you sure you want to decline this application?')) {
-                handleApplication(appId, 'decline');
-            }
-        });
-    });
-});
-
-function handleApplication(appId, action) {
-    fetch(`/org/application/${appId}/${action}/`, {
+    function handle(appId, action, rowEl) {
+      const url = '/org/application/' + appId + '/' + action + '/';
+      fetch(url, {
         method: 'POST',
         headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-CSRFToken': getCookie('csrftoken')
-        }
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            const card = document.getElementById(`application-${appId}`);
-            const actionsDiv = card.querySelector('.app-right');
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          if (!data || !data.success) {
+            throw new Error('Server rejected request');
+          }
+          const actions = rowEl.querySelector('.recent-app-row__actions');
+          const label = data.status.charAt(0).toUpperCase() + data.status.slice(1);
+          actions.innerHTML =
+            '<a class="btn-sm btn-sm--ghost" href="/org/applicant/' +
+            rowEl.dataset.studentId +
+            '/">View Profile</a>' +
+            '<span class="status-pill pill-' +
+            data.status +
+            '">' +
+            label +
+            '</span>';
+          rowEl.classList.remove('status-pending');
+          rowEl.classList.add('status-' + data.status);
+        })
+        .catch(function () {
+          alert('Could not update the application. Please try again.');
+        });
+    }
 
-            const statusClass = data.status === 'accepted' ? 'pill-accepted' : 'pill-declined';
-            const label = data.status === 'accepted' ? 'Accepted' : 'Declined';
-
-            actionsDiv.innerHTML = `
-                <div class="app-status-display">
-                    <span class="status-pill ${statusClass}">${label}</span>
-                </div>
-            `;
-
-            card.classList.remove('status-pending');
-            card.classList.add(`status-${data.status}`);
-            card.style.animation = 'fadeUpdate 0.4s ease';
-        }
-    })
-    .catch(err => {
-        alert('Something went wrong. Please try again.');
-        console.error(err);
+    document.querySelectorAll('.recent-app-row').forEach(function (row) {
+      const actions = row.querySelector('.recent-app-row__actions');
+      if (!actions) return;
+      const viewLink = row.querySelector('.btn-sm--ghost');
+      if (viewLink) {
+        const m = viewLink.getAttribute('href').match(/\/org\/applicant\/(\d+)\//);
+        if (m) row.dataset.studentId = m[1];
+      }
+      actions.querySelectorAll('button[data-action]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          const action = btn.dataset.action;
+          const appId = btn.dataset.appId;
+          if (action === 'decline' && !confirm('Decline this application?')) return;
+          handle(appId, action, row);
+        });
+      });
     });
-}
-
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
+  })();
 </script>
-
-<style>
-/* ── Org Dashboard ── */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
-.org-dashboard {
-    padding: 2rem 1rem;
-    max-width: 960px;
-    margin: 0 auto;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
-}
-
-/* Header */
-.dashboard-header {
-    margin-bottom: 2rem;
-}
-
-.header-greeting h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: #0f172a;
-    margin: 0 0 0.35rem 0;
-}
-
-.dashboard-header .subtitle {
-    color: #64748b;
-    font-size: 1rem;
-    margin: 0;
-}
-
-/* Stats Grid */
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem;
-    margin-bottom: 2rem;
-}
-
-.stat-card {
-    background: #ffffff;
-    border: 1px solid #e2e8f0;
-    border-radius: 12px;
-    padding: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.stat-card:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 6px 16px rgba(0,0,0,0.1);
-}
-
-.stat-icon-wrap {
-    width: 52px;
-    height: 52px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 12px;
-    font-size: 1.5rem;
-    flex-shrink: 0;
-}
-
-.stat-pending .stat-icon-wrap { background: #fef3c7; }
-.stat-profile .stat-icon-wrap { background: #dbeafe; }
-.stat-volunteers .stat-icon-wrap { background: #d1fae5; }
-
-.stat-label {
-    margin: 0;
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: #64748b;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.stat-number {
-    margin: 0.25rem 0 0 0;
-    font-size: 1.6rem;
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.stat-link-text {
-    font-size: 1.1rem !important;
-    color: #2563eb !important;
-}
-
-/* Quick Actions */
-.quick-actions {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 2.5rem;
-    flex-wrap: wrap;
-}
-
-.action-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: 10px;
-    text-decoration: none;
-    font-weight: 600;
-    font-size: 0.9rem;
-    transition: all 0.2s ease;
-    border: none;
-    cursor: pointer;
-}
-
-.action-primary {
-    background: linear-gradient(135deg, #2563eb, #1d4ed8);
-    color: #fff;
-    box-shadow: 0 2px 8px rgba(37,99,235,0.3);
-}
-
-.action-primary:hover {
-    background: linear-gradient(135deg, #1d4ed8, #1e40af);
-    box-shadow: 0 4px 14px rgba(37,99,235,0.4);
-    transform: translateY(-1px);
-}
-
-.action-secondary {
-    background: #f1f5f9;
-    color: #334155;
-    border: 1px solid #e2e8f0;
-}
-
-.action-secondary:hover {
-    background: #e2e8f0;
-    transform: translateY(-1px);
-}
-
-.action-icon {
-    font-size: 1.1rem;
-}
-
-/* Recent Applications */
-.recent-applications-section {
-    background: #ffffff;
-    border: 1px solid #e2e8f0;
-    border-radius: 16px;
-    padding: 1.75rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-}
-
-.section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1.5rem;
-}
-
-.section-header h2 {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.apps-badge {
-    background: linear-gradient(135deg, #2563eb, #1d4ed8);
-    color: white;
-    padding: 0.2rem 0.7rem;
-    border-radius: 20px;
-    font-size: 0.8rem;
-    font-weight: 600;
-}
-
-/* Application Cards */
-.applications-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.application-card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.25rem;
-    border-radius: 12px;
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    transition: all 0.25s ease;
-}
-
-.application-card:hover {
-    border-color: #cbd5e1;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
-}
-
-.application-card.status-accepted {
-    border-left: 4px solid #22c55e;
-}
-
-.application-card.status-declined {
-    border-left: 4px solid #ef4444;
-    opacity: 0.7;
-}
-
-.application-card.status-pending {
-    border-left: 4px solid #f59e0b;
-}
-
-.app-left {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex: 1;
-    min-width: 0;
-}
-
-.applicant-avatar {
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
-    color: white;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 1.1rem;
-    text-transform: uppercase;
-    flex-shrink: 0;
-}
-
-.applicant-info {
-    min-width: 0;
-}
-
-.applicant-name {
-    margin: 0;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: #0f172a;
-}
-
-.opportunity-title {
-    margin: 0.15rem 0 0;
-    font-size: 0.85rem;
-    color: #475569;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.applied-time {
-    margin: 0.15rem 0 0;
-    font-size: 0.75rem;
-    color: #94a3b8;
-}
-
-/* Actions */
-.app-right {
-    flex-shrink: 0;
-    margin-left: 1rem;
-}
-
-.app-actions {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    flex-wrap: wrap;
-}
-
-.app-status-display {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-}
-
-.action-btn-sm {
-    padding: 0.4rem 0.9rem;
-    border-radius: 8px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border: none;
-    cursor: pointer;
-    text-decoration: none;
-    display: inline-block;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-}
-
-.action-view {
-    background: #f1f5f9;
-    color: #334155;
-    border: 1px solid #e2e8f0;
-}
-
-.action-view:hover {
-    background: #e2e8f0;
-}
-
-.action-accept {
-    background: #22c55e;
-    color: white;
-}
-
-.action-accept:hover {
-    background: #16a34a;
-    box-shadow: 0 2px 6px rgba(34,197,94,0.3);
-}
-
-.action-decline {
-    background: #fff;
-    color: #ef4444;
-    border: 1px solid #fecaca;
-}
-
-.action-decline:hover {
-    background: #fef2f2;
-    border-color: #ef4444;
-}
-
-/* Status Pills */
-.status-pill {
-    padding: 0.3rem 0.7rem;
-    border-radius: 20px;
-    font-size: 0.75rem;
-    font-weight: 600;
-}
-
-.pill-accepted {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.pill-declined {
-    background: #fee2e2;
-    color: #991b1b;
-}
-
-.pill-pending {
-    background: #fef3c7;
-    color: #92400e;
-}
-
-/* Empty State */
-.empty-state {
-    text-align: center;
-    padding: 3rem 1.5rem;
-}
-
-.empty-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.empty-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: #334155;
-    margin: 0 0 0.5rem 0;
-}
-
-.empty-subtitle {
-    color: #94a3b8;
-    margin: 0;
-    font-size: 0.9rem;
-}
-
-/* Animation */
-@keyframes fadeUpdate {
-    0%   { opacity: 0.5; transform: scale(0.98); }
-    100% { opacity: 1;   transform: scale(1); }
-}
-
-/* Responsive */
-@media (max-width: 640px) {
-    .application-card {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
-    }
-
-    .app-right {
-        margin-left: 0;
-        width: 100%;
-    }
-
-    .app-actions {
-        width: 100%;
-    }
-
-    .action-btn-sm {
-        flex: 1;
-        text-align: center;
-    }
-
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .header-greeting h1 {
-        font-size: 1.4rem;
-    }
-}
-</style>
 {% endblock %}


### PR DESCRIPTION
## Overview
Implements the Organization Home Dashboard as defined in US-016. Organizations now land on a focused home page after login that gives a quick overview of recent applications and provides fast access to key actions — reviewing volunteers, posting opportunities, and messaging.

## What's Changed

### New Organization Home Dashboard (`/org/dashboard/`)
- **Greeting hero** — displays the organization's display name and initials avatar with a teal branded gradient header
- **Quick Action Cards (Row 1)** — Review Volunteers *(with pending count)*, Your Profile, Current Volunteers *(with accepted count)*
- **Quick Action Cards (Row 2)** — Post Opportunity, Share News Update *(with unread message badge)*
- **Recent Applications** — shows the last 5 applicants with avatar, name, opportunity title, time since applied, and inline **View Profile / Accept / Decline** buttons that update instantly via AJAX (no page reload)

### Routing
- `/dashboard/` now automatically redirects organization users to `/org/dashboard/` so the nav Dashboard link works seamlessly

### Files Changed
| File | Change |
|---|---|
| `templates/pages/organization_dashboard.html` | Rebuilt from scratch to match wireframe |
| `pages/views.py` | Updated `organization_dashboard` view (adds org_name, initials, unread count); `dashboard` redirects orgs |
| `static/css/styles.css` | Added `.org-home`, `.recent-app-row`, `.btn-sm`, `.status-pill` component styles |

## Acceptance Criteria
- [x] The dashboard shows recent applications
- [x] I can quickly view applicant details and take action — Accept or Decline
- [x] I can easily navigate to my profile, messages, and posted opportunities